### PR TITLE
refactor: refactor message deletion logic in MessagesViewModel

### DIFF
--- a/src/Eppie.App/Eppie.App.ViewModels/MessagesViewModel.cs
+++ b/src/Eppie.App/Eppie.App.ViewModels/MessagesViewModel.cs
@@ -285,19 +285,29 @@ namespace Tuvi.App.ViewModels
                 }
                 await DispatcherService.RunAsync(() =>
                 {
-                    var deletedMessage = messageList.FirstOrDefault(m => m.MessageID == e.MessageID && m.Email.HasSameAddress(e.Email) && m.Folder.HasSameName(e.Folder));
-
-                    if (deletedMessage != null)
-                    {
-                        messageList.Remove(deletedMessage);
-                    }
+                    RemoveMatchingMessage(messageList, e);
+                    RemoveMatchingMessage(messageList.OriginalItems, e);
                 }).ConfigureAwait(true);
             }
             catch (Exception ex)
             {
                 OnError(ex);
             }
+
+            void RemoveMatchingMessage(ICollection<MessageInfo> collection, MessageDeletedEventArgs arg)
+            {
+                var message = collection.FirstOrDefault(m =>
+                    m.MessageID == arg.MessageID &&
+                    m.Email.HasSameAddress(arg.Email) &&
+                    m.Folder.HasSameName(arg.Folder));
+
+                if (message != null)
+                {
+                    collection.Remove(message);
+                }
+            }
         }
+
         private async void OnMessagesAttributeChanged(object sender, MessagesAttributeChangedEventArgs e)
         {
             try


### PR DESCRIPTION
<!--
Please read the following before submitting:
- Keep your pull request as small as possible
- Name this pull request according the format: <type>(optional scope): <description>
- Please label this pull request
- Specify affected platforms
-->

## Issue
<!-- Please associate the pull request with a GitHub issue.
     e.g., 'Close #<ISSUE-NUMBER>', or 'Related to <ISSUE-LINK>', or 'N/A'. -->
N/A

## Description
<!-- Please describe the changes that this pull request introduces. -->
Updated the `OnMessageDeleted` method to use a new helper function `RemoveMatchingMessage` for improved readability and code reuse. This change allows for message removal from both `messageList` and `messageList.OriginalItems` collections through a single method.

## Other Information
<!-- Please provide any additional information if necessary. -->

## Pull Request Checklist

Please check if your pull request fulfills the following requirements:

- [x] The pull request is named according to the format: _[\<type\>](#types-of-pull-requests)(optional scope): \<description\>_
- [ ] The pull request is associated with a GitHub issue. Note: if possible use the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] [The pull request is labeled](#pull-request-labels)
- [x] [Affected platforms are labeled](#platform-labels)
- [x] Commits follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] There are no difficult to understand places left without comments
- [x] The changes do not generate new warnings

> [!NOTE]
>
> <details><summary><strong id="types-of-pull-requests">Types of pull requests</strong></summary>
>
> - `feat` - adding **new features**
> - `fix` - **bug** fixes
> - `test` - adding or correcting **tests**
> - `perf` - changes that improve **performance**
> - `refactor` - simple **rewriting** or **restructuring** of code without adding new features or fixing bugs
> - `style` - changes in **code styles** and no changes in logic
> - `build` - changes related to **the build of the project** and **dependencies**
> - `ci` - changes related to **continuous integration**
> - `docs` - changes in **documentation** or just **comments** in source code
> - `chore` - something that **doesn't fit** the other possible types
>
> </details>
>
> <details><summary><strong id="pull-request-labels">Pull request labels</strong></summary>
>
> - **`type/breaking-change`** - pull requests with changes that are **not backward compatible**
> - `type/build` - pull requests that change the **project's build** or **dependencies**
> - `type/chore` - pull requests **without** making **changes** to the code, project build, formatting, documentation, etc
> - `type/ci` - pull requests whose changes are related to **continuous integration**
> - `type/documentation` - pull requests that only change **documentation**
> - **`type/feature`** - pull requests that add **new features**
> - **`type/fix`** - pull requests that fix a **bug**
> - **`type/localization`** - pull requests that change **translation**
> - **`type/performance`** - pull requests that improve **performance**
> - `type/refactor` - pull requests that **refactor** a section of code
> - `type/style` - pull requests that change **code styles**
> - `type/test` - pull requests that add or correct **tests**
> - **`ignore-for-release`** - for pull requests that do **not need** to be appeared in **release notes**
>
> ---
> A pull request appears in the release notes if it has one of the labels: `type/breaking-change`, `type/feature`, `type/fix`, `type/localization`, `type/performance`
>
> </details>
>
> <details><summary><strong id="platform-labels">Affected platforms labels</strong></summary>
>
> - `platform/all` - pull requests that are related to the all platforms
> - `platform/android` - pull requests that are related to the Android platform
> - `platform/desktop` - pull requests that are related to the desktop
> - `platform/ios` - pull requests that are related to the iOS platform
> - `platform/macos` - pull requests that are related to the macOS platform
> - `platform/other` - pull requests that are related to an unknown platform
> - `platform/uwp` - pull requests that are related to the Universal Windows Platform
> - `platform/wasm` - pull requests that are related to the WebAssembly platform
> - `platform/winui` - pull requests that are related to the WinUI platform
>
> </details>
>
