### PR TITLE
feat: add a universal tooltip provider

### DIFF
--- a/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Controls/ToolTipProvider.cs
+++ b/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Controls/ToolTipProvider.cs
@@ -1,0 +1,94 @@
+﻿// ---------------------------------------------------------------------------- //
+//                                                                              //
+//   Copyright 2026 Eppie (https://eppie.io)                                    //
+//                                                                              //
+//   Licensed under the Apache License, Version 2.0 (the "License"),            //
+//   you may not use this file except in compliance with the License.           //
+//   You may obtain a copy of the License at                                    //
+//                                                                              //
+//       http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                              //
+//   Unless required by applicable law or agreed to in writing, software        //
+//   distributed under the License is distributed on an "AS IS" BASIS,          //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //
+//   See the License for the specific language governing permissions and        //
+//   limitations under the License.                                             //
+//                                                                              //
+// ---------------------------------------------------------------------------- //
+
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+#else
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+#endif
+
+namespace Eppie.App.UI.Controls
+{
+    /// <summary>
+    /// Provides attached properties for setting tooltips on UI elements.This class makes it easy to add tooltips
+    /// to any UWP and WinUI elements using the x:Uid property and string resources with a name in the format:
+    /// "{UID_KEY}.[using:Eppie.App.UI.Controls]ToolTipProvider.ToolTip"
+    /// </summary>
+
+    public static class ToolTipProvider
+    {
+        public static DependencyProperty ToolTipProperty { get; } = DependencyProperty.RegisterAttached("ToolTip", typeof(object), typeof(ToolTipProvider), new PropertyMetadata(null, OnUpdateToolTip));
+
+        public static object GetToolTip(DependencyObject element)
+        {
+            return element.GetValue(ToolTipProperty);
+        }
+
+        public static void SetToolTip(DependencyObject element, object value)
+        {
+            element.SetValue(ToolTipProperty, value);
+        }
+
+        public static DependencyProperty PlacementProperty { get; } = DependencyProperty.RegisterAttached("Placement", typeof(PlacementMode), typeof(ToolTipProvider), new PropertyMetadata(PlacementMode.Top, OnUpdateToolTip));
+
+        public static PlacementMode GetPlacement(DependencyObject element)
+        {
+            return (PlacementMode)element.GetValue(PlacementProperty);
+        }
+
+        public static void SetPlacement(DependencyObject element, PlacementMode value)
+        {
+            element.SetValue(PlacementProperty, value);
+        }
+
+        public static DependencyProperty PlacementTargetProperty { get; } = DependencyProperty.RegisterAttached("PlacementTarget", typeof(UIElement), typeof(ToolTipProvider), new PropertyMetadata(null, OnUpdateToolTip));
+
+        public static UIElement GetPlacementTarget(DependencyObject element)
+        {
+            return (UIElement)element.GetValue(PlacementTargetProperty);
+        }
+
+        public static void SetPlacementTarget(DependencyObject element, UIElement value)
+        {
+            element.SetValue(PlacementTargetProperty, value);
+        }
+
+        private static void OnUpdateToolTip(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element)
+            {
+                object content = GetToolTip(element);
+
+                if (content != null)
+                {
+                    ToolTipService.SetToolTip(element, content);
+                    ToolTipService.SetPlacement(element, GetPlacement(element));
+                    ToolTipService.SetPlacementTarget(element, GetPlacementTarget(element));
+                }
+                else
+                {
+                    ToolTipService.SetToolTip(element, null);
+                }
+            }
+        }
+    }
+}

--- a/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Controls/ToolTipProvider.cs
+++ b/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Controls/ToolTipProvider.cs
@@ -29,7 +29,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 namespace Eppie.App.UI.Controls
 {
     /// <summary>
-    /// Provides attached properties for setting tooltips on UI elements.This class makes it easy to add tooltips
+    /// Provides attached properties for setting tooltips on UI elements. This class makes it easy to add tooltips
     /// to any UWP and WinUI elements using the x:Uid property and string resources with a name in the format:
     /// "{UID_KEY}.[using:Eppie.App.UI.Controls]ToolTipProvider.ToolTip"
     /// </summary>

--- a/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Eppie.App.UI.Shared.projitems
+++ b/src/Eppie.App/Eppie.App.UI/Eppie.App.UI.Shared/Eppie.App.UI.Shared.projitems
@@ -42,6 +42,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ProtonSettingsControl.xaml.cs">
       <DependentUpon>ProtonSettingsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\ToolTipProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\EmailValidityToStyleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\SupportDevelopmentControl.xaml.cs">
       <DependentUpon>SupportDevelopmentControl.xaml</DependentUpon>


### PR DESCRIPTION
<!--
Please read the following before submitting:
- Keep your pull request as small as possible
- Name this pull request according the format: <type>(optional scope): <description>
- Please label this pull request
- Specify affected platforms
-->

## Issue
<!-- Please associate the pull request with a GitHub issue.
     e.g., 'Close #<ISSUE-NUMBER>', or 'Related to <ISSUE-LINK>', or 'N/A'. -->

Related to #1126

## Description
<!-- Please describe the changes that this pull request introduces. -->

Provides attached properties for setting tooltips on UI elements. 
This makes it easy to add tooltips to any UWP and WinUI elements using the x:Uid property and string resources with a name in the format: 
`"{UID_KEY}.[using:Eppie.App.UI.Controls]ToolTipProvider.ToolTip"`

## Other Information
<!-- Please provide any additional information if necessary. -->

## Pull Request Checklist

Please check if your pull request fulfills the following requirements:

- [x] The pull request is named according to the format: _[\<type\>](#types-of-pull-requests)(optional scope): \<description\>_
- [x] The pull request is associated with a GitHub issue. Note: if possible use the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] [The pull request is labeled](#pull-request-labels)
- [x] [Affected platforms are labeled](#platform-labels)
- [x] Commits follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] There are no difficult to understand places left without comments
- [x] The changes do not generate new warnings

> [!NOTE]
>
> <details><summary><strong id="types-of-pull-requests">Types of pull requests</strong></summary>
>
> - `feat` - adding **new features**
> - `fix` - **bug** fixes
> - `test` - adding or correcting **tests**
> - `perf` - changes that improve **performance**
> - `refactor` - simple **rewriting** or **restructuring** of code without adding new features or fixing bugs
> - `style` - changes in **code styles** and no changes in logic
> - `build` - changes related to **the build of the project** and **dependencies**
> - `ci` - changes related to **continuous integration**
> - `docs` - changes in **documentation** or just **comments** in source code
> - `chore` - something that **doesn't fit** the other possible types
>
> </details>
>
> <details><summary><strong id="pull-request-labels">Pull request labels</strong></summary>
>
> - **`type/breaking-change`** - pull requests with changes that are **not backward compatible**
> - `type/build` - pull requests that change the **project's build** or **dependencies**
> - `type/chore` - pull requests **without** making **changes** to the code, project build, formatting, documentation, etc
> - `type/ci` - pull requests whose changes are related to **continuous integration**
> - `type/documentation` - pull requests that only change **documentation**
> - **`type/feature`** - pull requests that add **new features**
> - **`type/fix`** - pull requests that fix a **bug**
> - **`type/localization`** - pull requests that change **translation**
> - **`type/performance`** - pull requests that improve **performance**
> - `type/refactor` - pull requests that **refactor** a section of code
> - `type/style` - pull requests that change **code styles**
> - `type/test` - pull requests that add or correct **tests**
> - **`ignore-for-release`** - for pull requests that do **not need** to be appeared in **release notes**
>
> ---
> A pull request appears in the release notes if it has one of the labels: `type/breaking-change`, `type/feature`, `type/fix`, `type/localization`, `type/performance`
>
> </details>
>
> <details><summary><strong id="platform-labels">Affected platforms labels</strong></summary>
>
> - `platform/all` - pull requests that are related to the all platforms
> - `platform/android` - pull requests that are related to the Android platform
> - `platform/desktop` - pull requests that are related to the desktop
> - `platform/ios` - pull requests that are related to the iOS platform
> - `platform/macos` - pull requests that are related to the macOS platform
> - `platform/other` - pull requests that are related to an unknown platform
> - `platform/uwp` - pull requests that are related to the Universal Windows Platform
> - `platform/wasm` - pull requests that are related to the WebAssembly platform
> - `platform/winui` - pull requests that are related to the WinUI platform
>
> </details>
>
